### PR TITLE
[DO NOT MERGE] Final gitleaks-scan requirement verification

### DIFF
--- a/devsec-final-verification.md
+++ b/devsec-final-verification.md
@@ -1,0 +1,1 @@
+Temporary canary verifying gitleaks-scan is the required check after ghom-manifests #164. Will be closed.


### PR DESCRIPTION
Verifies the required check moved from devsec/jenkins/gitleaks/leak-scan to gitleaks-scan after ghom-manifests #164. Will be closed shortly.